### PR TITLE
Broken under new versions of jquery

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -1,4 +1,4 @@
-$(document).on('ajaxComplete ready', function () {
+$(document).ready(function () {
 
     // Initialize text suggestions
     $('input[data-provides="anomaly.field_type.text"]:not([data-initialized])').each(function () {


### PR DESCRIPTION
document.on(ready) was deprecated in jquery 1.8 and removed in jquery 3. It's broken on all modern versions of jquery. The commented code causes errors and needs to be removed.